### PR TITLE
Add overrides to the themes

### DIFF
--- a/hydenix/default.nix
+++ b/hydenix/default.nix
@@ -70,12 +70,12 @@ in
       enable = true;
       settings = {
         "org/gnome/desktop/interface" = {
-          icon-theme = activeTheme.arcs.icon.name or "Tela-circle-dracula";
-          gtk-theme = activeTheme.arcs.gtk.name or "Wallbash-Gtk";
+          icon-theme = config.gtk.iconTheme.name or activeTheme.arcs.icon.name or "Tela-circle-dracula";
+          gtk-theme = config.gtk.theme.name or activeTheme.arcs.gtk.name or "Wallbash-Gtk";
           color-scheme = "prefer-dark";
           font-name = activeTheme.arcs.font.name or "Cantarell 10";
-          cursor-theme = activeTheme.arcs.cursor.name or "Bibata-Modern-Ice";
-          cursor-size = "20";
+          cursor-theme = config.pointerCursor.name or activeTheme.arcs.cursor.name or "Bibata-Modern-Ice";
+          cursor-size = config.pointerCursor.size or "20";
           document-font-name = activeTheme.arcs.font.name or "Cantarell 10";
           monospace-font-name = "JetBrains Mono 9";
           font-antialiasing = "rgba";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is a change that allows a user to directly modify their system themes in a separate file without conflicting definitions, something like home.pointerCursor still conflicts with the dconf theme for the cursor which I will try and figure out a fix for, a example configuration utilizing the feature I just add is shown as:
https://pastebin.com/n5Z9Ac2T
Which beforehand would conflict with hydenix, this change enables people to set various overrides for themes but a bit more work needs to be done.