### PR TITLE
fix: reconcile hydenix hm settings with default template settings

### DIFF
--- a/hydenix/modules/hm/social.nix
+++ b/hydenix/modules/hm/social.nix
@@ -16,30 +16,36 @@ in
       description = "Enable social module";
     };
 
-    discord = lib.mkOption {
+    discord = {
+      enable = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Enable discord module";
+      };
     };
 
-    webcord = lib.mkOption {
+    webcord = {
+      enable = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Enable webcord module";
+      };
     };
 
-    vesktop = lib.mkOption {
+    vesktop = {
+      enable = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Enable vesktop module";
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
     home.packages = with pkgs; [
-      (lib.mkIf cfg.discord discord)
-      (lib.mkIf cfg.webcord webcord)
-      (lib.mkIf cfg.vesktop vesktop)
+      (lib.mkIf cfg.discord.enable discord)
+      (lib.mkIf cfg.webcord.enable webcord)
+      (lib.mkIf cfg.vesktop.enable vesktop)
     ];
 
     home.file = {

--- a/template/modules/hm/default.nix
+++ b/template/modules/hm/default.nix
@@ -62,11 +62,10 @@
         satty.enable = true; # enable satty screenshot annotation tool
         swappy.enable = false; # enable swappy screenshot editor
       };
-      wallpapers.enable = true; # enable wallpapers module
       shell = {
         enable = true; # enable shell module
         zsh.enable = true; # enable zsh shell
-        configText = ""; # zsh config text
+        zsh.configText = ""; # zsh config text
         bash.enable = false; # enable bash shell
         fish.enable = false; # enable fish shell
         pokego.enable = true; # enable Pokemon ASCII art scripts
@@ -82,7 +81,7 @@
       terminals = {
         enable = true; # enable terminals module
         kitty.enable = true; # enable kitty terminal
-        configText = ""; # kitty config text
+        kitty.configText = ""; # kitty config text
       };
       theme = {
         enable = true; # enable theme module


### PR DESCRIPTION
## Description
The home-manager modules don't match the default template settings. This PR should address that.

## Type of change
<!-- Please delete options that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
<!-- Please check if your PR fulfills these requirements -->

- [X] My commits follow conventional commit format
- [X] I have updated the documentation accordingly
- [X] My changes generate no new warnings