### PR TITLE
feat: theme init and rebuild updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,10 +3,6 @@
 
 ## priority
 
-- [ ] fix: hyprlock supposed to have a background?
-  - [ ] still doesnt work on rebuild/first boot (tied to hyde-shell reload)
-- [ ] fix: rebuild properly changes theme during runtime
-- [ ] fix: slight flashing on rebuild
 - [ ] fix: boot module grub is not working?
 
 ## iso builder

--- a/hydenix/modules/hm/hyde.nix
+++ b/hydenix/modules/hm/hyde.nix
@@ -108,7 +108,6 @@ in
         force = true;
         mutable = true;
       };
-
     };
   };
 }

--- a/hydenix/modules/hm/hyprland.nix
+++ b/hydenix/modules/hm/hyprland.nix
@@ -27,6 +27,21 @@ in
       hypridle
     ];
 
+    home.activation.createHyprConfigs = lib.hm.dag.entryAfter [ "mutableGeneration" ] ''
+      mkdir -p "$HOME/.config/hypr/animations"
+      mkdir -p "$HOME/.config/hypr/themes"
+
+      touch "$HOME/.config/hypr/animations/theme.conf"
+      touch "$HOME/.config/hypr/themes/colors.conf"
+      touch "$HOME/.config/hypr/themes/theme.conf"
+      touch "$HOME/.config/hypr/themes/wallbash.conf"
+
+      chmod 644 "$HOME/.config/hypr/animations/theme.conf"
+      chmod 644 "$HOME/.config/hypr/themes/colors.conf"
+      chmod 644 "$HOME/.config/hypr/themes/theme.conf"
+      chmod 644 "$HOME/.config/hypr/themes/wallbash.conf"
+    '';
+
     home.file = {
       ".config/hypr/hyprland.conf" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/hypr/hyprland.conf";
@@ -104,27 +119,6 @@ in
 
       ".config/hypr/hypridle.conf" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/hypr/hypridle.conf";
-      };
-
-      ".config/hypr/animations/theme.conf" = lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/hypr/animations/theme.conf";
-        force = true;
-        mutable = true;
-      };
-      ".config/hypr/themes/colors.conf" = lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/hypr/themes/colors.conf";
-        force = true;
-        mutable = true;
-      };
-      ".config/hypr/themes/theme.conf" = lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/hypr/themes/theme.conf";
-        force = true;
-        mutable = true;
-      };
-      ".config/hypr/themes/wallbash.conf" = lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/hypr/themes/wallbash.conf";
-        force = true;
-        mutable = true;
       };
 
     };

--- a/hydenix/modules/hm/notifications.nix
+++ b/hydenix/modules/hm/notifications.nix
@@ -23,7 +23,7 @@ in
     ];
 
     home.file = {
-      # stateful file for themes
+      # # stateful file for themes
       ".config/dunst/dunstrc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/dunst/dunstrc";
         force = true;

--- a/hydenix/modules/hm/theme.nix
+++ b/hydenix/modules/hm/theme.nix
@@ -92,11 +92,15 @@ in
       # Set up logging
       LOG_FILE="$HOME/.local/state/hyde/theme-switch.log"
       mkdir -p $HOME/.local/state/hyde
+      # Clear the log file before writing
+      : > "$LOG_FILE"
+      chmod 644 $LOG_FILE
 
       echo "Setting theme to ${cfg.active}..." | tee -a "$LOG_FILE"
 
       # Run the theme switch commands with the custom runtime dir
-      $HOME/.local/lib/hyde/swwwallcache.sh -t "${cfg.active}" >> "$LOG_FILE" 2>&1
+      # $HOME/.local/lib/hyde/swwwallcache.sh -t "${cfg.active}" >> "$LOG_FILE" 2>&1
+      $HOME/.local/lib/hyde/theme.switch.sh -s "${cfg.active}" >> "$LOG_FILE" 2>&1
       $HOME/.local/lib/hyde/theme.switch.sh -s "${cfg.active}" >> "$LOG_FILE" 2>&1
 
       echo "Theme switch completed. Log saved to $LOG_FILE" | tee -a "$LOG_FILE"

--- a/hydenix/modules/hm/waybar.nix
+++ b/hydenix/modules/hm/waybar.nix
@@ -42,119 +42,119 @@ in
       # Modules for waybar
       # Note: some of these may not work for NixOS
       # TODO: review waybar modules for nix compatibility
-      ".config/waybar/modules/backlight.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/backlight.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/backlight.jsonc";
       };
-      ".config/waybar/modules/battery.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/battery.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/battery.jsonc";
       };
-      ".config/waybar/modules/bluetooth.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/bluetooth.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/bluetooth.jsonc";
       };
-      ".config/waybar/modules/cava.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/cava.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/cava.jsonc";
       };
-      ".config/waybar/modules/cliphist.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/cliphist.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/cliphist.jsonc";
       };
-      ".config/waybar/modules/clock##alt.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/clock##alt.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/clock##alt.jsonc";
       };
-      ".config/waybar/modules/clock.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/clock.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/clock.jsonc";
       };
-      ".config/waybar/modules/cpu.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/cpu.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/cpu.jsonc";
       };
-      ".config/waybar/modules/cpuinfo.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/cpuinfo.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/cpuinfo.jsonc";
       };
-      ".config/waybar/modules/display.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/display.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/display.jsonc";
       };
-      ".config/waybar/modules/github_hyde.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/github_hyde.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/github_hyde.jsonc";
       };
-      ".config/waybar/modules/gpuinfo.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/gpuinfo.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/gpuinfo.jsonc";
       };
-      ".config/waybar/modules/hyprsunset.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/hyprsunset.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/hyprsunset.jsonc";
       };
-      ".config/waybar/modules/idle_inhibitor.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/idle_inhibitor.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/idle_inhibitor.jsonc";
       };
 
-      ".config/waybar/modules/language.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/language.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/language.jsonc";
       };
-      ".config/waybar/modules/memory.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/memory.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/memory.jsonc";
       };
-      ".config/waybar/modules/mpris.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/mpris.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/mpris.jsonc";
       };
-      ".config/waybar/modules/network.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/network.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/network.jsonc";
       };
-      ".config/waybar/modules/notifications.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/notifications.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/notifications.jsonc";
       };
-      ".config/waybar/modules/power.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/power.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/power.jsonc";
       };
-      ".config/waybar/modules/privacy.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/privacy.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/privacy.jsonc";
       };
-      ".config/waybar/modules/pulseaudio.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/pulseaudio.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/pulseaudio.jsonc";
       };
-      ".config/waybar/modules/sensorsinfo.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/sensorsinfo.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/sensorsinfo.jsonc";
       };
-      ".config/waybar/modules/spotify.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/spotify.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/spotify.jsonc";
       };
-      ".config/waybar/modules/taskbar##custom.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/taskbar##custom.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/taskbar##custom.jsonc";
       };
-      ".config/waybar/modules/taskbar##windows.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/taskbar##windows.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/taskbar##windows.jsonc";
       };
-      ".config/waybar/modules/taskbar.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/taskbar.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/taskbar.jsonc";
       };
-      ".config/waybar/modules/theme.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/theme.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/theme.jsonc";
       };
-      ".config/waybar/modules/tray.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/tray.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/tray.jsonc";
       };
-      ".config/waybar/modules/updates.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/updates.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/updates.jsonc";
       };
-      ".config/waybar/modules/wbar.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/wbar.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/wbar.jsonc";
       };
-      ".config/waybar/modules/weather.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/weather.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/weather.jsonc";
       };
-      ".config/waybar/modules/window.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/window.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/window.jsonc";
       };
-      ".config/waybar/modules/workspaces##kanji.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/workspaces##kanji.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/workspaces##kanji.jsonc";
       };
-      ".config/waybar/modules/workspaces##roman.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/workspaces##roman.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/workspaces##roman.jsonc";
       };
-      ".config/waybar/modules/workspaces.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/workspaces.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/workspaces.jsonc";
       };
 
       # stateful files
       # for some reason this won't pull from the repo
-      ".config/waybar/modules/keyboardhint.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/keyboardhint.jsonc" = lib.mkDefault {
         text = ''
               "custom/keybindhint": {
               "format": " ",
@@ -163,44 +163,43 @@ in
               "on-click": "keybinds_hint.sh"
           },
         '';
-        force = true;
-        mutable = true;
       };
-      ".config/waybar/config.ctl" =  lib.mkDefault {
+      ".config/waybar/config.ctl" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/config.ctl";
         force = true;
         mutable = true;
       };
-      ".config/waybar/config.jsonc" =  lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/config.jsonc";
-        force = true;
-        mutable = true;
-      };
-      ".config/waybar/modules/header.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/header.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/header.jsonc";
         force = true;
         mutable = true;
       };
-      ".config/waybar/modules/footer.jsonc" =  lib.mkDefault {
+      ".config/waybar/modules/footer.jsonc" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/footer.jsonc";
         mutable = true;
         force = true;
       };
-      ".config/waybar/style.css" =  lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/style.css";
-        force = true;
-        mutable = true;
-      };
-      ".config/waybar/modules/style.css" =  lib.mkDefault {
+
+      ".config/waybar/modules/style.css" = lib.mkDefault {
         source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/modules/style.css";
         force = true;
         mutable = true;
       };
-      ".config/waybar/theme.css" =  lib.mkDefault {
-        source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/theme.css";
-        force = true;
-        mutable = true;
-      };
+      # ".config/waybar/config.jsonc" =  lib.mkDefault {
+      #   source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/config.jsonc";
+      #   force = true;
+      #   mutable = true;
+      # };
+      # ".config/waybar/style.css" = lib.mkDefault {
+      #   source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/style.css";
+      #   force = true;
+      #   mutable = true;
+      # };
+      # ".config/waybar/theme.css" =  lib.mkDefault {
+      #   source = "${pkgs.hydenix.hyde}/Configs/.config/waybar/theme.css";
+      #   force = true;
+      #   mutable = true;
+      # };
 
     };
   };


### PR DESCRIPTION
 - fixes hyprlock from not initing correctly
 - increases first build time by removing swwwallcache.sh call
 - wallbash and hyprland no longer flash when rebuilding
 - themes init correctly
 - themes correctly change when rebuilding if config is different