### PR TITLE
fix(shell): add missing hyde_config.fish file to fish configuration

### DIFF
--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -262,6 +262,7 @@ in
       (lib.mkIf cfg.fish.enable {
         # Fish configs
         ".config/fish/config.fish".source = "${pkgs.hydenix.hyde}/Configs/.config/fish/config.fish";
+        ".config/fish/hyde_config.fish".source = "${pkgs.hydenix.hyde}/Configs/.config/fish/hyde_config.fish";
         ".config/fish/functions/df.fish".source =
           "${pkgs.hydenix.hyde}/Configs/.config/fish/functions/df.fish";
         ".config/fish/functions/ffcd.fish".source =


### PR DESCRIPTION

## Description
Include hyde_config.fish in home.file configuration to fix error: ~/.config/fish/hyde_config.fish no such file or directory present when enabling the fish shell in hydenix project.

This was caused by the hyde_config.fish not being sourced from the upstream hyde repository in shell.nix. 

Added:     ".config/fish/hyde_config.fish".source = "${pkgs.hydenix.hyde}/Configs/.config/fish/hyde_config.fish"; to 
# hydenix/modules/hm/shell.nix


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My commits follow conventional commit format
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings