### PR TITLE
fix(shell): set programs.fish.enable when cfg.fish.enable is true

### DIFF
--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -92,21 +92,18 @@ in
       [
         fastfetch
       ]
+      ++ lib.optionals (cfg.zsh.enable || cfg.fish.enable) [
+         eza
+         duf
+      ]
       ++ lib.optionals cfg.zsh.enable [
         zsh
-        eza
         oh-my-zsh
         zsh-autosuggestions
         zsh-syntax-highlighting
-        duf
       ]
       ++ lib.optionals cfg.bash.enable [ bash ]
-      ++ lib.optionals cfg.fish.enable [
-        fish
-        duf
-        fzf
-        eza
-      ]
+      ++ lib.optionals cfg.fish.enable [ fish ]
       ++ lib.optionals cfg.pokego.enable [ pokego ]
       ++ lib.optionals cfg.starship.enable [ starship ]
       ++ lib.optionals cfg.p10k.enable [ zsh-powerlevel10k ];
@@ -146,6 +143,7 @@ in
 
     programs.fish = lib.mkIf cfg.fish.enable {
       enable = true;
+      #reimpementing the HyDE-Project config.fish using home.manager
       interactiveShellInit = ''
         # fzf integration
         if type -q fzf

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -104,6 +104,7 @@ in
       ++ lib.optionals cfg.fish.enable [
         fish
         duf
+        fzf
       ]
       ++ lib.optionals cfg.pokego.enable [ pokego ]
       ++ lib.optionals cfg.starship.enable [ starship ]
@@ -144,6 +145,16 @@ in
 
     programs.fish = lib.mkIf cfg.fish.enable {
       enable = true;
+      interactiveShellInit = ''
+        # fzf integration
+        if type -q fzf
+          fzf --fish | source
+        end
+        
+        # Color settings
+        set fish_pager_color_prefix cyan
+        set fish_color_autosuggestion brblack
+      '';
     };
 
     home.file = lib.mkMerge [

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -154,6 +154,14 @@ in
         set fish_pager_color_prefix cyan
         set fish_color_autosuggestion brblack
       '';
+      shellAliases = {
+        l = "eza -lh --icons=auto";
+        ls = "eza -1 --icons=auto";
+        ll = "eza -lha --icons=auto --sort=name --group-directories-first";
+        ld = "eza -lhD --icons=auto";
+        lt = "eza --icons=auto --tree";
+        vc = "code";
+      };
       shellAbbrs = {
         ".." = "cd ..";
         "..." = "cd ../..";

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -105,6 +105,7 @@ in
         fish
         duf
         fzf
+        eza
       ]
       ++ lib.optionals cfg.pokego.enable [ pokego ]
       ++ lib.optionals cfg.starship.enable [ starship ]

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -142,6 +142,10 @@ in
       '';
     };
 
+    programs.fish = lib.mkIf cfg.fish.enable {
+      enable = true;
+    };
+
     home.file = lib.mkMerge [
       (lib.mkIf cfg.zsh.enable {
         # Shell configs

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -145,6 +145,17 @@ in
       enable = true;
       #reimpementing the HyDE-Project config.fish using home.manager
       interactiveShellInit = ''
+        # Source Hyde configuration
+        source ${pkgs.hydenix.hyde}/Configs/.config/fish/hyde_config.fish
+        
+        ${lib.optionalString cfg.starship.enable ''
+          if type -q starship
+            starship init fish | source
+            set -gx STARSHIP_CACHE $XDG_CACHE_HOME/starship
+            set -gx STARSHIP_CONFIG $XDG_CONFIG_HOME/starship/starship.toml
+          end
+        ''}
+        
         # fzf integration
         if type -q fzf
           fzf --fish | source
@@ -153,6 +164,14 @@ in
         # Color settings
         set fish_pager_color_prefix cyan
         set fish_color_autosuggestion brblack
+        
+        ${lib.optionalString cfg.pokego.enable ''
+          pokego --no-title -r 1,3,6
+        ''}
+        
+        ${lib.optionalString cfg.fastfetch.enable ''
+          fastfetch --logo-type kitty
+        ''}
       '';
       shellAliases = {
         l = "eza -lh --icons=auto";

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -145,6 +145,9 @@ in
       enable = true;
       #reimpementing the HyDE-Project config.fish using home.manager
       interactiveShellInit = ''
+        # Disable greeting
+        set -g fish_greeting
+        
         # Source Hyde configuration
         source ${pkgs.hydenix.hyde}/Configs/.config/fish/hyde_config.fish
         

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -283,7 +283,6 @@ in
 
       (lib.mkIf cfg.fish.enable {
         # Fish configs
-        ".config/fish/config.fish".source = "${pkgs.hydenix.hyde}/Configs/.config/fish/config.fish";
         ".config/fish/hyde_config.fish".source = "${pkgs.hydenix.hyde}/Configs/.config/fish/hyde_config.fish";
         ".config/fish/functions/df.fish".source =
           "${pkgs.hydenix.hyde}/Configs/.config/fish/functions/df.fish";

--- a/hydenix/modules/hm/shell.nix
+++ b/hydenix/modules/hm/shell.nix
@@ -156,6 +156,14 @@ in
         set fish_pager_color_prefix cyan
         set fish_color_autosuggestion brblack
       '';
+      shellAbbrs = {
+        ".." = "cd ..";
+        "..." = "cd ../..";
+        ".3" = "cd ../../..";
+        ".4" = "cd ../../../..";
+        ".5" = "cd ../../../../..";
+        mkdir = "mkdir -p";
+      };
     };
 
     home.file = lib.mkMerge [


### PR DESCRIPTION
Added conditional check and enable in  /hydenix/modules/hm/shell.nix

## Description
Found that on a new install fish.pkg was not being installed when enabling it. Added conditional check for the option and enabled the package if the user uses the fish.enable option in shell.nix. Followed the existing zsh implementation style in the same file.  

## Type of change
Bug fix as nix-rebuild will not work if the fish pkg is not enabled somewhere. 

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x ] My commits follow conventional commit format
- [x ] My changes generate no new warnings
