### PR TITLE
fix: correct neovim option syntax in docs and add missing system context

### DIFF
--- a/template/configuration.nix
+++ b/template/configuration.nix
@@ -12,6 +12,7 @@ let
       inputs.hydenix.lib.overlays
       (final: prev: {
         userPkgs = import inputs.nixpkgs {
+          inherit (pkgs) system;
           config.allowUnfree = true;
         };
       })

--- a/template/docs/options.md
+++ b/template/docs/options.md
@@ -115,7 +115,7 @@ below are the default options for hydenix. they are in *object format* and any o
       dolphin.enable = true; # file manager
       editors = {
         enable = true; # enable editors module
-        neovim.enable = true; # enable neovim module
+        neovim = true; # enable neovim module
         vscode = {
           enable = true; # enable vscode module
           wallbash = true; # enable wallbash extension for vscode


### PR DESCRIPTION
## Description
This PR addresses two small issues i encountered while tweaking template flake:

1. Documentation fix: Corrected the neovim configuration syntax in
template/docs/options.md from neovim.enable = true to neovim = true to match
the actual interface.
2. Configuration fix: Added missing system context to userPkgs in
template/configuration.nix to prevent evaluation errors when using the
overlay.

## Type of change

[✓] Bug fix (non-breaking change which fixes an issue)
[✓] Documentation update

## Checklist

[✓] My commits follow conventional commit format
[✓] I have updated the documentation accordingly
[✓] My changes generate no new warnings