### PR TITLE
fix(configuration.nix): use of outdated nix-index-database output hmM…

### DIFF
--- a/template/configuration.nix
+++ b/template/configuration.nix
@@ -69,7 +69,7 @@ in
       {
         imports = [
           inputs.hydenix.lib.homeModules
-          inputs.nix-index-database.hmModules.nix-index # Command-not-found and comma tool support
+          inputs.nix-index-database.homeModules.nix-index # Command-not-found and comma tool support
           ./modules/hm # Your custom home-manager modules (configure hydenix.hm here!)
         ];
       };


### PR DESCRIPTION
## Description
Tiny fix for evaluation warning:

> before and after change
<img width="1910" height="251" alt="image" src="https://github.com/user-attachments/assets/7584e57b-4cce-403b-a23c-cbe4e7d9c30c" />

## Type of change
<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Please check if your PR fulfills these requirements -->

- [x] My commits follow conventional commit format
- [x] My changes generate no new warnings