### PR TITLE
fix: changed hyde-shell execution to use bashInteractive

### DIFF
--- a/hydenix/modules/hm/hyde.nix
+++ b/hydenix/modules/hm/hyde.nix
@@ -86,7 +86,7 @@ in
       ".local/bin/hyde-shell" = {
         source = pkgs.writeShellScript "hyde-shell" ''
           export PYTHONPATH="${pkgs.python-pyamdgpuinfo}/${pkgs.python3.sitePackages}:$PYTHONPATH"
-          exec "${pkgs.hyde}/Configs/.local/bin/hyde-shell" "$@"
+          exec ${pkgs.bashInteractive}/bin/bash "${pkgs.hyde}/Configs/.local/bin/hyde-shell" "$@"
         '';
         executable = true;
       };


### PR DESCRIPTION
## Description

Changed hyde-shell execution to use bashInteractive

## Type of change

This prevents that the following error be triggered:

```
~/.config/NixOS feat/hydenix*
❯ hyde-shell
/nix/store/41p02idzg7qib93isxqyqr7zdn0yijz1-hyde-modified/Configs/.local/bin/hyde-shell: line 615: compgen: command not found
```

compgen is not available for the minimal bach instalations that nix uses for its writeShellScript funciton.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
<!-- Please check if your PR fulfills these requirements -->

- [ x ] My commits follow conventional commit format
- [ x ] I have updated the documentation accordingly
- [ x ] My changes generate no new warnings